### PR TITLE
feat: Disable Vercel build cache

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -21,6 +21,11 @@
       "runtime": "nodejs18.x"
     }
   },
+  "build": {
+    "env": {
+      "VERCEL_FORCE_NO_BUILD_CACHE": "1"
+    }
+  },
   "env": {
     "NODE_ENV": "production"
   }


### PR DESCRIPTION
To ensure that Vercel always deploys the latest version of the code from GitHub, this change introduces the `VERCEL_FORCE_NO_BUILD_CACHE` environment variable in the `vercel.json` configuration.

This forces Vercel to perform a clean build on every deployment, preventing stale code from being served.